### PR TITLE
Add scoped Mode3D and Drawing classes in raylib::core::scopes namespace

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,8 @@
 #include <iostream>
-#include "raylib/core/Camera3D.hpp"
-#include "raylib/core/Window.hpp"
 #include "logger/Logger.hpp"
+#include "raylib/core/Camera3D.hpp"
+#include "raylib/core/Scopes.hpp"
+#include "raylib/core/Window.hpp"
 
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
@@ -14,12 +15,13 @@ static void drawFrame(void *arg)
 {
     raylib::core::Camera3D *camera = reinterpret_cast<raylib::core::Camera3D *>(arg);
 
-    raylib::core::Window::beginDrawing();
+    raylib::core::scopes::Drawing drawing;
     raylib::core::Window::clear();
-    camera->begin3D();
-    camera->end3D();
+    {
+        raylib::core::scopes::Mode3D mode3D(*camera);
+    };
+
     DrawText("<insert great game here>", WIDTH / 2 - 120, HEIGHT / 2 - 1, 20, LIGHTGRAY);
-    raylib::core::Window::endDrawing();
     raylib::core::Window::drawFPS(10, 10);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 #include "logger/Logger.hpp"
 #include "raylib/core/Camera3D.hpp"
-#include "raylib/core/Scopes.hpp"
 #include "raylib/core/Window.hpp"
+#include "raylib/core/scoped.hpp"
 
 #if defined(PLATFORM_WEB)
     #include <emscripten/emscripten.h>
@@ -15,10 +15,10 @@ static void drawFrame(void *arg)
 {
     raylib::core::Camera3D *camera = reinterpret_cast<raylib::core::Camera3D *>(arg);
 
-    raylib::core::scopes::Drawing drawing;
+    raylib::core::scoped::Drawing drawing;
     raylib::core::Window::clear();
     {
-        raylib::core::scopes::Mode3D mode3D(*camera);
+        raylib::core::scoped::Mode3D mode3D(*camera);
     };
 
     DrawText("<insert great game here>", WIDTH / 2 - 120, HEIGHT / 2 - 1, 20, LIGHTGRAY);

--- a/src/raylib/core/CMakeLists.txt
+++ b/src/raylib/core/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SRC
     ${SRCROOT}/Window.hpp
     ${SRCROOT}/Mouse.hpp
     ${SRCROOT}/Mouse.cpp
-    ${SRCROOT}/Scopes.hpp
+    ${SRCROOT}/scoped.hpp
     ${SRCROOT}/Cursor.hpp
     ${SRCROOT}/Cursor.cpp
     ${SRCROOT}/Color.hpp

--- a/src/raylib/core/CMakeLists.txt
+++ b/src/raylib/core/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRC
     ${SRCROOT}/Window.hpp
     ${SRCROOT}/Mouse.hpp
     ${SRCROOT}/Mouse.cpp
+    ${SRCROOT}/Scopes.hpp
     ${SRCROOT}/Cursor.hpp
     ${SRCROOT}/Cursor.cpp
     ${SRCROOT}/Color.hpp

--- a/src/raylib/core/Camera3D.hpp
+++ b/src/raylib/core/Camera3D.hpp
@@ -52,7 +52,7 @@ namespace raylib
                 void begin3D();
 
                 /// End 3D mode (EndMode3D encapsulation)
-                void end3D();
+                static void end3D();
 
                 /// Get the position of the camera
                 ///

--- a/src/raylib/core/Scopes.hpp
+++ b/src/raylib/core/Scopes.hpp
@@ -1,0 +1,49 @@
+/*
+** EPITECH PROJECT, 2022
+** Bomberman
+** File description:
+** Scoped3D
+*/
+
+#ifndef RAYLIB_CORE_SCOPED3D_HPP_
+#define RAYLIB_CORE_SCOPED3D_HPP_
+
+#include "Camera3D.hpp"
+#include "Window.hpp"
+
+/// Raylib namespace
+namespace raylib
+{
+    /// Core namespace (inside of raylib)
+    namespace core
+    {
+        /// Use of RAII for the raylib Drawing related functions (with begin/end for each).
+        namespace scopes
+        {
+            /// Setup/End a 3D mode with a custom camera
+            class Mode3D {
+              public:
+                /// Begin the Mode3D with the given camera.
+                ///
+                /// @param camera custom camera.
+                inline Mode3D(Camera3D &camera) { camera.begin3D(); };
+
+                /// End the Mode3D
+                inline ~Mode3D() { Camera3D::end3D(); };
+            };
+
+            /// Setup/End window drawing
+            class Drawing {
+              public:
+                /// Begin the window drawing.
+                inline Drawing() { Window::beginDrawing(); }
+
+                /// End the window drawing.
+                inline ~Drawing() { Window::endDrawing(); }
+            };
+        } // namespace scopes
+
+    } // namespace core
+} // namespace raylib
+
+#endif /* !RAYLIB_CORE_SCOPED3D_HPP_ */

--- a/src/raylib/core/scoped.hpp
+++ b/src/raylib/core/scoped.hpp
@@ -18,7 +18,7 @@ namespace raylib
     namespace core
     {
         /// Use of RAII for the raylib Drawing related functions (with begin/end for each).
-        namespace scopes
+        namespace scoped
         {
             /// Setup/End a 3D mode with a custom camera
             class Mode3D {
@@ -41,7 +41,7 @@ namespace raylib
                 /// End the window drawing.
                 inline ~Drawing() { Window::endDrawing(); }
             };
-        } // namespace scopes
+        } // namespace scoped
 
     } // namespace core
 } // namespace raylib


### PR DESCRIPTION
Multiple raylib drawing functions need a begin and end function call. The namespace scopes will contain classes using RAII model to call the begin... on construction and end... on destruction.
It avoid calling begin... and forgetting the associated end function.

Resolve: #31