### PR TITLE
Add colors and names to loggers.

### DIFF
--- a/src/logger/Logger.cpp
+++ b/src/logger/Logger.cpp
@@ -21,7 +21,7 @@
 
 Logger Logger::logger;
 
-Logger::Logger(std::ostream &stream)
+Logger::Logger(std::ostream &stream, std::string_view name) : _name(name)
 {
     setDefaultColors();
     setStream(stream);
@@ -63,6 +63,9 @@ void Logger::displayInformations(std::stringstream &ss)
             writeInfo();
         firstInfo = false;
     };
+
+    if (!_name.empty())
+        ss << "[" << _name << "] ";
 
     if ((*this)[LogInfo::PID])
         add_info("PID", [&]() {
@@ -156,3 +159,7 @@ void Logger::setSeverityColor(Severity severity, Color foreground, Color backgro
 {
     _colors[static_cast<size_t>(severity)] = {foreground, background};
 }
+
+void Logger::setName(std::string_view name) { _name = name; }
+
+std::string_view Logger::getName() const { return _name; }

--- a/src/logger/Logger.cpp
+++ b/src/logger/Logger.cpp
@@ -23,12 +23,14 @@ Logger Logger::logger;
 
 Logger::Logger(std::ostream &stream)
 {
+    setDefaultColors();
     setStream(stream);
     setLogInfo(LogInfo::Time);
 }
 
 Logger::Logger(const std::filesystem::path &filepath, bool clear)
 {
+    setDefaultColors();
     setOutputFile(filepath, clear);
     setLogInfo(LogInfo::Time);
 }
@@ -88,9 +90,15 @@ void Logger::log(Severity severity, std::function<void(std::ostream &)> writer)
         {Severity::Information, "INFO"}, {Severity::Warning, "WARN"}, {Severity::Error, "ERROR"}};
     std::stringstream ss;
 
+    if (_streamPointer == &std::cout || _streamPointer == &std::cerr)
+        ss << "\033[" << 30 + static_cast<size_t>(_colors[static_cast<size_t>(severity)].first) << ";"
+           << 40 + static_cast<size_t>(_colors[static_cast<size_t>(severity)].second) << "m";
+
     displayInformations(ss);
     ss << "[" << severityNames[severity] << "] : ";
     writer(ss);
+    if (_streamPointer == &std::cout || _streamPointer == &std::cerr)
+        ss << "\033[0m";
     ss << std::endl;
     (*_streamPointer) << ss.str();
 }
@@ -135,3 +143,16 @@ void Logger::enableLogInfo(bool enabled, LogInfo info) { (*this)[info] = enabled
 bool Logger::operator[](LogInfo logInfo) const { return _infos[static_cast<size_t>(logInfo)]; }
 
 bool &Logger::operator[](LogInfo logInfo) { return _infos[static_cast<size_t>(logInfo)]; }
+
+void Logger::setDefaultColors()
+{
+    setSeverityColor(Severity::Debug, Color::Blue);
+    setSeverityColor(Severity::Information, Color::Green);
+    setSeverityColor(Severity::Warning, Color::Yellow);
+    setSeverityColor(Severity::Error, Color::Red);
+}
+
+void Logger::setSeverityColor(Severity severity, Color foreground, Color background)
+{
+    _colors[static_cast<size_t>(severity)] = {foreground, background};
+}

--- a/src/logger/Logger.hpp
+++ b/src/logger/Logger.hpp
@@ -59,7 +59,7 @@ class Logger {
     /// Construct a new Logger object linked to a given output stream.
     ///
     /// @param[in] stream stream in which the logger will write.
-    Logger(std::ostream &stream = std::cerr);
+    Logger(std::ostream &stream = std::cerr, std::string_view name = "");
 
     /// Construct a new Logger object linked to a logfile.
     ///
@@ -174,6 +174,16 @@ class Logger {
     /// @param background background color.
     void setSeverityColor(Severity severity, Color foreground, Color background = Color::Black);
 
+    /// Set the Name of the logger.
+    /// @note If empty the name isn't printed.
+    ///
+    /// @param name name of the logger.
+    void setName(std::string_view name);
+
+    /// Get the name of the logger.
+    /// @return std::string_view name of the logger, might be empty.
+    std::string_view getName() const;
+
   private:
     void displayInformations(std::stringstream &ss);
     void displayTime(std::stringstream &ss, std::string_view format);
@@ -183,6 +193,7 @@ class Logger {
     std::ostream *_streamPointer;
     std::ofstream _fileStream;
     std::array<ColorPair, static_cast<size_t>(Severity::Count)> _colors;
+    std::string _name;
 };
 
 #endif /* !RAYLIB_LOGGER_LOGGER_HPP_ */

--- a/src/logger/Logger.hpp
+++ b/src/logger/Logger.hpp
@@ -37,6 +37,21 @@ class Logger {
         Count,    /// Number of available displays
     };
 
+    /// Available colors in terminals (when using stdout/stderr).
+    enum class Color {
+        Black,   /// Black color, not used by default
+        Red,     /// Red color, default to Error logs
+        Green,   /// Green color, default to Information logs
+        Yellow,  /// Yellow color, default to Warning logs
+        Blue,    /// Blue color, default to Debug logs
+        Magenta, /// Magenta color, not used by default
+        Cyan,    /// Cyan color, not used by default
+        White,   /// White color, default for all uncolored texts
+    };
+
+    /// Color pairs are used to associate foreground and background colors together
+    using ColorPair = std::pair<Color, Color>;
+
     /// Default global logger.
     /// @note You need to flush it before forking processes to avoid cache data duplication.
     static Logger logger;
@@ -147,6 +162,18 @@ class Logger {
         enableLogInfo(true, info, args...);
     }
 
+    /// Reset the default colors.
+    /// @note Colors are only used when the logger prints on stdout/stderr.
+    void setDefaultColors();
+
+    /// Set the color of a severity.
+    /// @note Multiple severities can have the same color but it isn't recommended for readability.
+    ///
+    /// @param severity severity to affect.
+    /// @param foreground foreground color.
+    /// @param background background color.
+    void setSeverityColor(Severity severity, Color foreground, Color background = Color::Black);
+
   private:
     void displayInformations(std::stringstream &ss);
     void displayTime(std::stringstream &ss, std::string_view format);
@@ -155,6 +182,7 @@ class Logger {
     Severity _logLevel = Severity::Information;
     std::ostream *_streamPointer;
     std::ofstream _fileStream;
+    std::array<ColorPair, static_cast<size_t>(Severity::Count)> _colors;
 };
 
 #endif /* !RAYLIB_LOGGER_LOGGER_HPP_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,6 @@ static void raylibLogger(int msgType, const char *text, va_list args)
 static void setupLogger()
 {
     // Setup the logger parameters
-    Logger::logger.setOutputFile("log.txt");
     Logger::logger.setLogLevel(Logger::Severity::Information);
     Logger::logger.setLogInfo(Logger::LogInfo::Time);
     SetTraceLogCallback(raylibLogger);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ static void drawFrame(void *arg)
 
 static void raylibLogger(int msgType, const char *text, va_list args)
 {
-    static Logger raylibLogger("log_raylib.txt", true);
+    static Logger raylibLogger(std::cerr, "raylib");
     Logger::Severity severity;
     std::array<char, 1024> buffer;
 
@@ -82,6 +82,7 @@ static void setupLogger()
     // Setup the logger parameters
     Logger::logger.setLogLevel(Logger::Severity::Information);
     Logger::logger.setLogInfo(Logger::LogInfo::Time);
+    Logger::logger.setName("main");
     SetTraceLogCallback(raylibLogger);
     SetTraceLogLevel(LOG_INFO);
 }


### PR DESCRIPTION
Add colors based on logs severity when a logger print in stdout/stderr.
Also add the possibility to name the logger, allowing to have the bomberman logger and the raylib logger in stderr.

Resolves: #93 