### PR TITLE
Fix error when ecs::join-ing with unregistered components

### DIFF
--- a/src/ecs/resource/Timer.hpp
+++ b/src/ecs/resource/Timer.hpp
@@ -5,6 +5,9 @@
 ** ECS - Timer World Resource
 */
 
+#ifndef ECS_RESOURCE_TIMER_HPP_
+#define ECS_RESOURCE_TIMER_HPP_
+
 #include "ecs/resource/Resource.hpp"
 
 #include <chrono>
@@ -28,3 +31,5 @@ namespace ecs
         std::chrono::steady_clock::time_point _lastReset;
     };
 } // namespace ecs
+
+#endif // !defined(ECS_RESOURCE_TIMER_HPP_)

--- a/src/ecs/world/World.hpp
+++ b/src/ecs/world/World.hpp
@@ -118,6 +118,25 @@ namespace ecs
             this->_systems.emplace<S>("tried to register same system type twice", std::forward<Args>(args)...);
         }
 
+        /// Registers a component's storage.
+        ///
+        /// Normally, component storages are auto-registered when the @ref EntityBuilder::with() method is called.
+        /// But you wouldn't be able to use @ref ecs::maybe() with a Component that is not used by any entity in the
+        /// world.
+        ///
+        /// Use this function when you want to perform optional joins with the component @b C that might not be present
+        /// in the current entities.
+        ///
+        /// @tparam C The component type to register.
+        ///
+        /// @returns A reference to the Component's storage.
+        template <std::derived_from<Component> C> getStorageType<C> &addStorage()
+        {
+            if (!this->_storages.contains<getStorageType<C>>())
+                return this->_storages.emplace<getStorageType<C>>("failed to add entity component");
+            return this->_storages.get<getStorageType<C>>("failed to fetch storage");
+        }
+
 #pragma endregion ECS World Populating
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Running

--- a/tests/ecs/tests_Join.cpp
+++ b/tests/ecs/tests_Join.cpp
@@ -225,3 +225,33 @@ TEST(Join, optionalAlternativeOrdering)
     });
     world.runSystem<TestSystem>();
 }
+
+TEST(Join, optionalMissingComponent)
+{
+    ecs::World world;
+
+    world.addStorage<Marker>();
+
+    world.addEntity().with<Position>(5.0f, 6.0f).build();
+    world.addEntity().with<Position>(7.0f, 8.0f).build();
+
+    world.addSystem<TestSystem>([](ecs::SystemData data) {
+        auto optionalMarkers = ecs::maybe(data.getStorage<Marker>());
+        auto &positions = data.getStorage<Position>();
+
+        auto join = ecs::join(optionalMarkers, positions);
+        auto iter = join.begin();
+
+        auto [m1, p1] = *iter;
+        auto [m2, p2] = *(++iter);
+
+        EXPECT_TRUE(m1 == nullptr);
+        EXPECT_FLOAT_EQ(p1.x, 5.0f);
+        EXPECT_FLOAT_EQ(p1.y, 6.0f);
+
+        EXPECT_TRUE(m2 == nullptr);
+        EXPECT_FLOAT_EQ(p2.x, 7.0f);
+        EXPECT_FLOAT_EQ(p2.y, 8.0f);
+    });
+    world.runSystem<TestSystem>();
+}


### PR DESCRIPTION
Add the World::addStorage() function to force the registration of a component

Closes #112