### PR TITLE
Fix Windows CI

### DIFF
--- a/src/ecs/join/Join.hpp
+++ b/src/ecs/join/Join.hpp
@@ -18,6 +18,7 @@
 #include "ecs/join/Joinable.hpp"
 #include "util/BitSet.hpp"
 
+#include <algorithm>
 #include <concepts>
 #include <cstdint>
 #include <functional>


### PR DESCRIPTION
Fix undefined reference to external symbol (max) on windows CI