### PR TITLE
Add AssetMap ecs resource

### DIFF
--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -31,6 +31,7 @@
 #include "raylib/core/Vector3.hpp"
 #include "raylib/core/Window.hpp"
 #include "raylib/core/scoped.hpp"
+#include "raylib/textures/Texture2D.hpp"
 
 #include "resources/AssetMap.hpp"
 #include "resources/Map.hpp"

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -32,6 +32,7 @@
 #include "raylib/core/Window.hpp"
 #include "raylib/core/scoped.hpp"
 
+#include "resources/AssetMap.hpp"
 #include "resources/Map.hpp"
 
 #include "systems/Bomb.hpp"
@@ -111,6 +112,7 @@ namespace game
         _world.addResource<game::Users>();
         _world.addResource<ecs::Timer>();
         _world.addResource<resources::Map>(_map);
+        _world.addResource<resources::Textures>();
         /// Add world storages
         _world.addStorage<components::Bomb>();
         _world.addStorage<game::gui::Widget>();

--- a/src/game/resources/AssetMap.hpp
+++ b/src/game/resources/AssetMap.hpp
@@ -10,9 +10,13 @@
 
 #include <string>
 #include "ecs/resource/Resource.hpp"
-#include "raylib/textures/Texture2D.hpp"
 #include <string_view>
 #include <unordered_map>
+
+namespace raylib::textures
+{
+    class Texture2D;
+}
 
 namespace game::resources
 {

--- a/src/game/resources/AssetMap.hpp
+++ b/src/game/resources/AssetMap.hpp
@@ -1,0 +1,68 @@
+/*
+** EPITECH PROJECT, 2022
+** Bomberman
+** File description:
+** AssetMap
+*/
+
+#ifndef GAME_RESOURCES_ASSETSMAP_HPP_
+#define GAME_RESOURCES_ASSETSMAP_HPP_
+
+#include <string>
+#include "ecs/resource/Resource.hpp"
+#include "raylib/textures/Texture2D.hpp"
+#include <string_view>
+#include <unordered_map>
+
+namespace game::resources
+{
+    /// Map used to store assets (fonts, textures...) with strings as keys.
+    ///
+    /// @tparam T type of the assets to store.
+    template <typename T> class AssetMap : public ecs::Resource {
+      public:
+        /// Default constructor.
+        AssetMap() {}
+
+        /// Destructor, call @c clear.
+        ~AssetMap() { clear(); }
+
+        /// Add an asset by copy, prefer use @ref emplace() when possible.
+        ///
+        /// @param name name of the asset.
+        /// @param asset value of the asset.
+        void add(const std::string &name, const T &asset) { _assets[name] = asset; }
+
+        /// Add a new asset in the map.
+        ///
+        /// @param name asset name.
+        /// @param args arguments that will be passed to the asset's constructor.
+        template <typename... Args> void emplace(const std::string &name, Args &&...args)
+        {
+            _assets.emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                std::forward_as_tuple(std::forward<Args>(args)...));
+        }
+
+        /// Access to an asset stored in the map.
+        ///
+        /// @param name name of the asset.
+        /// @return const T& reference to the asset.
+        /// @throw std::out_of_range If there is no asset matching @c name in the map.
+        const T &get(const std::string &name) const { return _assets.at(name); }
+
+        /// Clear the asset map.
+        void clear(void) { _assets.clear(); }
+
+        /// Get the number of assets registered.
+        ///
+        /// @return size_t number of assets registered.
+        size_t getSize() const { return _assets.size(); }
+
+      private:
+        std::unordered_map<std::string, T> _assets;
+    };
+
+    using Textures = AssetMap<raylib::textures::Texture2D>;
+} // namespace game::resources
+
+#endif /* !GAME_RESOURCES_ASSETSMAP_HPP_ */

--- a/src/game/resources/CMakeLists.txt
+++ b/src/game/resources/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SRCROOT ${SRCROOT}/resources)
 
 set(SRC
     ${SRC}
+    ${SRCROOT}/AssetMap.hpp
     ${SRCROOT}/Map.hpp
     PARENT_SCOPE)
 


### PR DESCRIPTION
A Textures assetMap is defined in AssetMap.hpp (resources::Textures)

Usage:

```
/// Load textures
world.getResource<resources::Textures>().emplace("crate", "assets/map/crate.png");
/// Retrieve textures
world.getResource<resources::Textures>().get("crate")
```


Resolves: #164
