### PR TITLE
Fix multiple mesh/model issues

### DIFF
--- a/src/game/components/CMakeLists.txt
+++ b/src/game/components/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRC
     ${INCROOT}/Model.hpp
     ${INCROOT}/Position.hpp
     ${INCROOT}/Position2D.hpp
+    ${INCROOT}/Reference.hpp
     ${INCROOT}/RotationAngle.hpp
     ${INCROOT}/RotationAxis.hpp
     ${INCROOT}/Scale.hpp

--- a/src/game/components/Model.hpp
+++ b/src/game/components/Model.hpp
@@ -9,6 +9,7 @@
 #define GAME_COMPONENTS_MODEL_HPP_
 
 #include <filesystem>
+#include "Reference.hpp"
 #include "ecs/Component.hpp"
 #include "raylib/model/Mesh.hpp"
 #include "raylib/model/Model.hpp"
@@ -20,6 +21,8 @@ namespace game::components
         Model(const raylib::model::Mesh &pMesh) : raylib::model::Model(pMesh) {}
         Model(const std::filesystem::path &pPath) : raylib::model::Model(pPath) {}
     };
+
+    using ModelReference = Reference<raylib::model::Model>;
 } // namespace game::components
 
 #endif

--- a/src/game/components/Model.hpp
+++ b/src/game/components/Model.hpp
@@ -17,8 +17,7 @@
 namespace game::components
 {
     struct Model : public ecs::Component, public raylib::model::Model {
-        Model(const raylib::model::Model &pModel) : raylib::model::Model(pModel) {}
-        Model(const raylib::model::Mesh &pMesh) : raylib::model::Model(pMesh) {}
+        Model(const raylib::model::Mesh &pMesh, bool ownsMesh = true) : raylib::model::Model(pMesh, ownsMesh) {}
         Model(const std::filesystem::path &pPath) : raylib::model::Model(pPath) {}
     };
 

--- a/src/game/components/Reference.hpp
+++ b/src/game/components/Reference.hpp
@@ -1,0 +1,24 @@
+/*
+** EPITECH PROJECT, 2022
+** BMGO
+** File description:
+** Reference
+*/
+
+#ifndef GAME_COMPONENTS_REFERENCE_HPP_
+#define GAME_COMPONENTS_REFERENCE_HPP_
+
+#include "ecs/Component.hpp"
+
+namespace game::components
+{
+    /// Templated Reference component.
+    /// @tparam T type of the object wrapped.
+    template <typename T> struct Reference : public ecs::Component {
+        T &object;
+
+        Reference(const T &pObject) : object(pObject) {}
+    };
+} // namespace game::components
+
+#endif

--- a/src/game/components/Reference.hpp
+++ b/src/game/components/Reference.hpp
@@ -17,7 +17,7 @@ namespace game::components
     template <typename T> struct Reference : public ecs::Component {
         T &object;
 
-        Reference(const T &pObject) : object(pObject) {}
+        Reference(T &pObject) : object(pObject) {}
     };
 } // namespace game::components
 

--- a/src/game/resources/AssetMap.hpp
+++ b/src/game/resources/AssetMap.hpp
@@ -13,10 +13,17 @@
 #include <string_view>
 #include <unordered_map>
 
-namespace raylib::textures
+namespace raylib
 {
-    class Texture2D;
-}
+    namespace textures
+    {
+        class Texture2D;
+    }
+    namespace model
+    {
+        class Mesh;
+    }
+} // namespace raylib
 
 namespace game::resources
 {
@@ -67,6 +74,7 @@ namespace game::resources
     };
 
     using Textures = AssetMap<raylib::textures::Texture2D>;
+    using Meshes = AssetMap<raylib::model::Mesh>;
 } // namespace game::resources
 
 #endif /* !GAME_RESOURCES_ASSETSMAP_HPP_ */

--- a/src/game/resources/AssetMap.hpp
+++ b/src/game/resources/AssetMap.hpp
@@ -49,10 +49,13 @@ namespace game::resources
         ///
         /// @param name asset name.
         /// @param args arguments that will be passed to the asset's constructor.
-        template <typename... Args> void emplace(const std::string &name, Args &&...args)
+        /// @return T& created asset.
+        template <typename... Args> T &emplace(const std::string &name, Args &&...args)
         {
-            _assets.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                std::forward_as_tuple(std::forward<Args>(args)...));
+            _assets
+                .emplace(std::piecewise_construct, std::forward_as_tuple(name),
+                    std::forward_as_tuple(std::forward<Args>(args)...))
+                .first->second;
         }
 
         /// Access to an asset stored in the map.
@@ -61,6 +64,13 @@ namespace game::resources
         /// @return const T& reference to the asset.
         /// @throw std::out_of_range If there is no asset matching @c name in the map.
         const T &get(const std::string &name) const { return _assets.at(name); }
+
+        /// Access to an asset stored in the map.
+        ///
+        /// @param name name of the asset.
+        /// @return T& reference to the asset.
+        /// @throw std::out_of_range If there is no asset matching @c name in the map.
+        T &get(const std::string &name) { return _assets.at(name); }
 
         /// Clear the asset map.
         void clear(void) { _assets.clear(); }

--- a/src/game/resources/AssetMap.hpp
+++ b/src/game/resources/AssetMap.hpp
@@ -22,7 +22,8 @@ namespace raylib
     namespace model
     {
         class Mesh;
-    }
+        class Model;
+    } // namespace model
 } // namespace raylib
 
 namespace game::resources
@@ -75,6 +76,7 @@ namespace game::resources
 
     using Textures = AssetMap<raylib::textures::Texture2D>;
     using Meshes = AssetMap<raylib::model::Mesh>;
+    using Models = AssetMap<raylib::model::Model>;
 } // namespace game::resources
 
 #endif /* !GAME_RESOURCES_ASSETSMAP_HPP_ */

--- a/src/game/resources/AssetMap.hpp
+++ b/src/game/resources/AssetMap.hpp
@@ -52,7 +52,7 @@ namespace game::resources
         /// @return T& created asset.
         template <typename... Args> T &emplace(const std::string &name, Args &&...args)
         {
-            _assets
+            return _assets
                 .emplace(std::piecewise_construct, std::forward_as_tuple(name),
                     std::forward_as_tuple(std::forward<Args>(args)...))
                 .first->second;

--- a/src/game/scenes/TestScene.cpp
+++ b/src/game/scenes/TestScene.cpp
@@ -126,13 +126,12 @@ static void loadTestScene(ecs::World &world)
     raylib::core::Vector3 rotationAxis(1.f, 0.f, 0.f);
     float rotationAngle = -90;
 
-    raylib::model::Model &testingModel = getTestingModel();
     raylib::model::Animation &testingAnimation = getTestingAnimation();
 
     world.addSystem<game::systems::DrawModel>();
     world.addSystem<game::systems::RunAnimation>();
     world.addEntity()
-        .with<game::components::Model>(testingModel)
+        .with<game::components::ModelReference>(getTestingModel())
         .with<game::components::Position>(pos)
         .with<game::components::Size>(size)
         .with<game::components::RotationAngle>(rotationAngle)

--- a/src/game/systems/Animation.hpp
+++ b/src/game/systems/Animation.hpp
@@ -27,9 +27,16 @@ namespace game
         struct RunAnimation : public ecs::System {
             void run(ecs::SystemData data) override final
             {
-                for (auto [model, animation] : ecs::join(
-                         data.getStorage<game::components::Model>(), data.getStorage<game::components::Animation>())) {
-                    animation.updateModel(model);
+                auto models = ecs::maybe(data.getStorage<game::components::Model>());
+                auto modelRefs = ecs::maybe(data.getStorage<game::components::ModelReference>());
+
+                for (auto [model, modelRef, animation] :
+                    ecs::join(models, modelRefs, data.getStorage<game::components::Animation>())) {
+                    auto obj = (model) ? model : ((modelRef) ? &modelRef->object : nullptr);
+
+                    if (!obj)
+                        continue;
+                    animation.updateModel(*obj);
                 }
             }
         };

--- a/src/game/systems/Model.hpp
+++ b/src/game/systems/Model.hpp
@@ -24,20 +24,26 @@ namespace game::systems
     struct DrawModel : public ecs::System {
         void run(ecs::SystemData data) override final
         {
-            auto &models = data.getStorage<game::components::Model>();
+            auto models = ecs::maybe(data.getStorage<game::components::Model>());
+            auto modelRefs = ecs::maybe(data.getStorage<game::components::ModelReference>());
             auto &poses = data.getStorage<game::components::Position>();
-            auto &scales = data.getStorage<game::components::Scale>();
             auto &colors = data.getStorage<game::components::Color>();
-            auto &sizes = data.getStorage<game::components::Size>();
-            auto &rAxises = data.getStorage<game::components::RotationAxis>();
-            auto &rAngles = data.getStorage<game::components::RotationAngle>();
+            auto scales = ecs::maybe(data.getStorage<game::components::Scale>());
+            auto sizes = ecs::maybe(data.getStorage<game::components::Size>());
+            auto rAxises = ecs::maybe(data.getStorage<game::components::RotationAxis>());
+            auto rAngles = ecs::maybe(data.getStorage<game::components::RotationAngle>());
 
-            for (auto [model, pos, scale, color] : ecs::join(models, poses, scales, colors)) {
-                model.draw(pos, scale.scale, color);
-            }
-            for (auto [model, pos, rAxis, rAngle, size, color] :
-                ecs::join(models, poses, rAxises, rAngles, sizes, colors)) {
-                model.draw(pos, rAxis, rAngle.rotationAngle, size, color);
+            for (auto [model, modelRef, pos, color, scale, size, rAxis, rAngle] :
+                ecs::join(models, modelRefs, poses, colors, scales, sizes, rAxises, rAngles)) {
+                auto obj = (model) ? model : ((modelRef) ? &modelRef->object : nullptr);
+
+                if (!obj)
+                    continue;
+                /// Prior to extended draw.
+                if (size && rAxis && rAngle)
+                    obj->draw(pos, *rAxis, rAngle->rotationAngle, *size, color);
+                else if (scale)
+                    obj->draw(pos, scale->scale, color);
             }
         }
     };

--- a/src/raylib/model/Mesh.cpp
+++ b/src/raylib/model/Mesh.cpp
@@ -11,25 +11,23 @@ namespace raylib
 {
     namespace model
     {
-        Mesh::Mesh(const Mesh &other) : _mesh(other._mesh) {}
-
         Mesh::Mesh(const ::Mesh &mesh) : _mesh(mesh) {}
 
-        Mesh::~Mesh() {}
+        Mesh::Mesh(float width, float height, float length) { _mesh = GenMeshCube(width, height, length); }
 
-        Mesh Mesh::genCube(float width, float height, float length) { return Mesh(GenMeshCube(width, height, length)); }
+        Mesh::Mesh(const raylib::core::Vector3f &size) { _mesh = GenMeshCube(size.x, size.y, size.z); }
 
-        Mesh Mesh::genCube(const raylib::core::Vector3f &size) { return Mesh(GenMeshCube(size.x, size.y, size.z)); }
-
-        Mesh genCubicMap(const raylib::textures::Image &image, float width, float height, float length)
+        Mesh::Mesh(const raylib::textures::Image &image, float width, float height, float length)
         {
-            return Mesh(GenMeshCubicmap(image.asRaylib(), {.x = width, .y = height, .z = length}));
+            _mesh = GenMeshCubicmap(image.asRaylib(), {.x = width, .y = height, .z = length});
         }
 
-        Mesh genCubicMap(const raylib::textures::Image &image, const raylib::core::Vector3f &vector)
+        Mesh::Mesh(const raylib::textures::Image &image, const raylib::core::Vector3f &vector)
         {
-            return Mesh(GenMeshCubicmap(image.asRaylib(), vector.asRaylib()));
+            _mesh = GenMeshCubicmap(image.asRaylib(), vector.asRaylib());
         }
+
+        Mesh::~Mesh() { UnloadMesh(_mesh); }
 
         ::Mesh const &Mesh::asRaylib() const { return _mesh; }
     } // namespace model

--- a/src/raylib/model/Mesh.hpp
+++ b/src/raylib/model/Mesh.hpp
@@ -21,57 +21,59 @@ namespace raylib::model
     class Mesh {
       public:
         /// Deleted default constructor
+        /// @note Deleted because it would try to unload an invalid mesh on destruction.
         Mesh() = delete;
-
-        /// Deleted copy operator
-        Mesh &operator=(const Mesh &other) = delete;
-
-        /// Mesh copy constructor
-        ///
-        /// @param other the mesh to copy
-        Mesh(const Mesh &other);
 
         /// C Raylib mesh import constructor
         ///
         /// @param mesh the C Raylib mesh to import
         Mesh(const ::Mesh &mesh);
 
+        /// Generates a cubic mesh
+        ///
+        /// @param width the width of the cube
+        /// @param height the height of the cube
+        /// @param length the length of the cube
+        ///
+        /// @return The created cubic mesh
+        Mesh(float width, float height, float length);
+
+        /// Generates a cubic mesh
+        ///
+        /// @param size the size of the cube
+        ///
+        /// @return The created cubic mesh
+        Mesh(const raylib::core::Vector3f &size);
+
+        /// Generates a cubic map mesh from an image
+        ///
+        /// @param image the image used to generate the mesh
+        /// @param width the width of the cube
+        /// @param height the height of the cube
+        /// @param length the length of the cube
+        ///
+        /// @return The created cubic mesh
+        Mesh(const raylib::textures::Image &image, float width, float height, float length);
+
+        /// Generates a cubic map mesh from an image
+        ///
+        /// @param image the image used to generate the mesh
+        /// @param size the size of the cube
+        ///
+        /// @return The created cubic mesh
+        Mesh(const raylib::textures::Image &image, const raylib::core::Vector3f &vector);
+
+        /// Mesh copy constructor
+        /// @note Deleted because it would cause double unload.
+        Mesh(const Mesh &other) = delete;
+
+        /// Deleted copy operator
+        /// @note Deleted because it would cause double unload.
+        Mesh &operator=(const Mesh &other) = delete;
+
         /// Destructor
+        /// @warning Unload the mesh.
         ~Mesh();
-
-        /// Generates a cubic mesh
-        ///
-        /// @param width the width of the cube
-        /// @param height the height of the cube
-        /// @param length the length of the cube
-        ///
-        /// @return The created cubic mesh
-        static Mesh genCube(float width, float height, float length);
-
-        /// Generates a cubic mesh
-        ///
-        /// @param size the size of the cube
-        ///
-        /// @return The created cubic mesh
-        static Mesh genCube(const raylib::core::Vector3f &size);
-
-        /// Generates a cubic map mesh from an image
-        ///
-        /// @param image the image used to generate the mesh
-        /// @param width the width of the cube
-        /// @param height the height of the cube
-        /// @param length the length of the cube
-        ///
-        /// @return The created cubic mesh
-        static Mesh genCubicMap(const raylib::textures::Image &image, float width, float height, float length);
-
-        /// Generates a cubic map mesh from an image
-        ///
-        /// @param image the image used to generate the mesh
-        /// @param size the size of the cube
-        ///
-        /// @return The created cubic mesh
-        static Mesh genCubicMap(const raylib::textures::Image &image, const raylib::core::Vector3f &vector);
 
         /// Gets the C Raylib immutable version of the mesh
         ///

--- a/src/raylib/model/Model.cpp
+++ b/src/raylib/model/Model.cpp
@@ -13,13 +13,24 @@ namespace raylib
     namespace model
     {
         Model::Model(const std::filesystem::path &modelPath)
-            : _model(LoadModel(modelPath.generic_string().c_str())), _path(modelPath)
+            : _model(LoadModel(modelPath.generic_string().c_str())), _ownsMesh(true)
         {
         }
 
-        Model::Model(const raylib::model::Mesh &mesh) : _model(LoadModelFromMesh(mesh.asRaylib())) {}
+        Model::Model(const raylib::model::Mesh &mesh, bool ownsMesh)
+            : _model(LoadModelFromMesh(mesh.asRaylib())), _ownsMesh(ownsMesh)
+        {
+        }
 
-        Model::~Model() { UnloadModel(_model); }
+        Model::Model(const Model &other, bool ownsMesh) : _model(other._model), _ownsMesh(ownsMesh) {}
+
+        Model::~Model()
+        {
+            if (_ownsMesh)
+                UnloadModel(_model);
+            else
+                UnloadModelKeepMeshes(_model);
+        }
 
         void Model::draw(raylib::core::Vector3f position, float scale, raylib::core::Color tint) const
         {
@@ -58,12 +69,12 @@ namespace raylib
 
         ::Model const &Model::asRaylib() const { return _model; }
 
-        Model::Model(const Model &other) : _path(other._path) { _model = LoadModel(_path.generic_string().c_str()); }
-
         void Model::setMaterialMapTexture(const raylib::textures::Texture2D &texture, int materialId, int mapType)
         {
             SetMaterialTexture(&_model.materials[materialId], mapType, texture.asRaylib());
         }
+
+        void Model::setOwnsMesh(bool ownsMesh) { _ownsMesh = ownsMesh; }
 
     } // namespace model
 } // namespace raylib

--- a/src/raylib/model/Model.cpp
+++ b/src/raylib/model/Model.cpp
@@ -22,8 +22,6 @@ namespace raylib
         {
         }
 
-        Model::Model(const Model &other, bool ownsMesh) : _model(other._model), _ownsMesh(ownsMesh) {}
-
         Model::~Model()
         {
             if (_ownsMesh)

--- a/src/raylib/model/Model.hpp
+++ b/src/raylib/model/Model.hpp
@@ -37,15 +37,17 @@ namespace raylib
             /// Model constructor. Used to initialize a 3D model from a mesh
             ///
             /// @param mesh the mesh from which to create the 3d model
-            Model(const raylib::model::Mesh &mesh);
-
-            /// Model destructor
-            ~Model();
+            /// @param ownsMesh if the model owns the mesh, see @ref setOwnsMesh().
+            Model(const raylib::model::Mesh &mesh, bool ownsMesh = true);
 
             /// Copy constructor
             ///
             /// @param other the model to copy
-            Model(const Model &other);
+            /// @param ownsMesh if the model owns the mesh, see @ref setOwnsMesh().
+            Model(const Model &other, bool ownsMesh = false);
+
+            /// Model destructor
+            ~Model();
 
             /// Deleted copy operator because it makes no sense to load the same file multiple simes
             Model &operator=(const Model &other) = delete;
@@ -124,9 +126,15 @@ namespace raylib
             /// @param mapType the map type to replace the texture
             void setMaterialMapTexture(const raylib::textures::Texture2D &texture, int materialId, int mapType);
 
+            /// Set the model as owner of the mesh or not.
+            /// @note Model owning a mesh will unload it on destruction.
+            ///
+            /// @param ownsMesh If the model owns the mesh.
+            void setOwnsMesh(bool ownsMesh = true);
+
           private:
             ::Model _model;
-            std::filesystem::path _path;
+            bool _ownsMesh;
         };
     } // namespace model
 } // namespace raylib

--- a/src/raylib/model/Model.hpp
+++ b/src/raylib/model/Model.hpp
@@ -40,11 +40,9 @@ namespace raylib
             /// @param ownsMesh if the model owns the mesh, see @ref setOwnsMesh().
             Model(const raylib::model::Mesh &mesh, bool ownsMesh = true);
 
-            /// Copy constructor
-            ///
-            /// @param other the model to copy
-            /// @param ownsMesh if the model owns the mesh, see @ref setOwnsMesh().
-            Model(const Model &other, bool ownsMesh = false);
+            /// Deleted copy constructor
+            /// @note Deleted to avoid double unloads.
+            Model(const Model &other) = delete;
 
             /// Model destructor
             ~Model();


### PR DESCRIPTION
Delete the model copy constructor causing double model unloads.

Use the ModelReference component instead of copying a model.

Resolves: #111