### PR TITLE
Remove speed items max stack

### DIFF
--- a/src/game/components/items/ChainBall.cpp
+++ b/src/game/components/items/ChainBall.cpp
@@ -16,12 +16,17 @@ namespace game::components
 
         chainBall.type = Item::Type::PowerDown;
         chainBall.identifier = Item::Identifier::ChainBall;
-        chainBall.maxStack = 5;
+        chainBall.maxStack = 0;
         chainBall.name = "Chain ball";
         chainBall.duration = std::chrono::milliseconds::zero();
         chainBall.dropRate = 30;
         chainBall.onApply = [](ecs::Entity player, ecs::SystemData data) {
-            data.getStorage<Player>()[player.getId()].stats.speed -= Player::Stats::DEFAULT_SPEED * 0.1f;
+            auto &speed = data.getStorage<Player>()[player.getId()].stats.speed;
+
+            if (speed > Player::Stats::DEFAULT_SPEED * 0.5f) {
+                speed -= Player::Stats::DEFAULT_SPEED * 0.1f;
+                return true;
+            }
             return true;
         };
         return chainBall;

--- a/src/game/components/items/SpeedShoes.cpp
+++ b/src/game/components/items/SpeedShoes.cpp
@@ -16,13 +16,18 @@ namespace game::components
 
         shoes.type = Item::Type::PowerUp;
         shoes.identifier = Item::Identifier::SpeedShoes;
-        shoes.maxStack = 5;
+        shoes.maxStack = 0;
         shoes.name = "Speed Shoes";
         shoes.duration = std::chrono::milliseconds::zero();
         shoes.dropRate = 30;
         shoes.onApply = [](ecs::Entity player, ecs::SystemData data) {
-            data.getStorage<Player>()[player.getId()].stats.speed += Player::Stats::DEFAULT_SPEED * 0.1f;
-            return true;
+            auto &speed = data.getStorage<Player>()[player.getId()].stats.speed;
+
+            if (speed < Player::Stats::DEFAULT_SPEED * 1.5f) {
+                speed += Player::Stats::DEFAULT_SPEED * 0.1f;
+                return true;
+            }
+            return false;
         };
         return shoes;
     }


### PR DESCRIPTION
Speed items doesn't have any more stack limit. The player speed is limited to [50%-150%] of its base speed.

Resolves: #207 