### PR TITLE
Implemented GameClock

### DIFF
--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -50,6 +50,7 @@
 
 #include "resources/AssetMap.hpp"
 #include "resources/Engine.hpp"
+#include "resources/GameClock.hpp"
 #include "resources/Map.hpp"
 #include "resources/RandomDevice.hpp"
 
@@ -67,6 +68,7 @@
 #include "systems/NoClip.hpp"
 #include "systems/PlaySoundOnce.hpp"
 #include "systems/Smoke.hpp"
+#include "systems/UpdateGameClock.hpp"
 #include "systems/UpdateKeyboardInput.hpp"
 
 #include "game/Engine.hpp"
@@ -222,6 +224,7 @@ namespace game
         _world.addResource<resources::Models>();
         _world.addResource<resources::Sounds>();
         _world.addResource<resources::RandomDevice>();
+        _world.addResource<resources::GameClock>();
         /// Add world storages
         _world.addStorage<components::Bomb>();
         _world.addStorage<components::ItemIdentifier>();
@@ -249,12 +252,13 @@ namespace game
         _world.addSystem<systems::PlaySoundReferences>();
         _world.addSystem<systems::DisableNoClip>();
         _world.addSystem<systems::CheckGameEnd>();
+        _world.addSystem<systems::UpdateGameClock>();
         /// Setup world systems tags
         _handleInputs.add<systems::InputManager>();
         _update.add<systems::Movement, systems::ExplodeBomb, systems::PickupItem, systems::DisableBombNoClip,
             systems::UpdateItemTimer, systems::RunAnimation, systems::MoveSmoke, systems::CheckGameEnd,
             systems::PlaySoundReferences, systems::DisableNoClip>();
-        _resolveCollisions.add<systems::Collision>();
+        _resolveCollisions.add<systems::Collision, systems::UpdateGameClock>();
         _drawing.add<systems::DrawModel>();
 
         _loadTextures();

--- a/src/game/components/Bomb.cpp
+++ b/src/game/components/Bomb.cpp
@@ -24,6 +24,7 @@
 #include "ecs/join.hpp"
 #include "game/Game.hpp"
 #include "game/resources/AssetMap.hpp"
+#include "game/resources/GameClock.hpp"
 #include "game/resources/Map.hpp"
 #include "items/Item.hpp"
 #include "logger/Logger.hpp"
@@ -151,7 +152,8 @@ namespace game::components
         auto builder = entities.builder();
 
         (void)Bomb::setBombModel(builder, data, bombType)
-            .with<Bomb>(data.getStorage<Bomb>(), bombType, owner, range, delay)
+            .with<Bomb>(data.getStorage<Bomb>(), data.getResource<game::resources::GameClock>().getTime(), bombType,
+                owner, range, delay)
             .with<Position>(data.getStorage<Position>(), placedPos)
             .with<Collidable>(data.getStorage<Collidable>());
         if (fabsf(velocity.x) > 0.f || fabsf(velocity.z) > 0.f)
@@ -169,7 +171,7 @@ namespace game::components
     {
         placeBomb(game::Game::worldPosToMapCell(data.getStorage<Position>()[self.getId()]), data, type, owner, radius,
             std::chrono::duration_cast<std::chrono::milliseconds>(
-                explosionDelay - (std::chrono::steady_clock::now() - placedTime)),
+                explosionDelay - (data.getResource<game::resources::GameClock>().getTime() - placedTime)),
             senderVelocity, false);
         /// Kill static bomb
         data.getResource<ecs::Entities>().kill(self);
@@ -179,7 +181,7 @@ namespace game::components
     {
         placeBomb(game::Game::worldPosToMapCell(data.getStorage<Position>()[self.getId()]), data, type, owner, radius,
             std::chrono::duration_cast<std::chrono::milliseconds>(
-                explosionDelay - (std::chrono::steady_clock::now() - placedTime)),
+                explosionDelay - (data.getResource<game::resources::GameClock>().getTime() - placedTime)),
             {}, false);
         /// Kill moving bomb
         data.getResource<ecs::Entities>().kill(self);

--- a/src/game/components/Bomb.hpp
+++ b/src/game/components/Bomb.hpp
@@ -27,7 +27,7 @@ namespace game::components
             LandMine,
         };
         /// Time when the bomb was placed
-        std::chrono::steady_clock::time_point placedTime;
+        std::chrono::milliseconds placedTime;
         /// Radius of the bomb explosion
         size_t radius;
         /// Delay before the explosion
@@ -48,10 +48,10 @@ namespace game::components
         /// @param pOwner @ref owner.
         /// @param pRadius @ref radius
         /// @param pExplosionDelay @ref explosionDelay
-        Bomb(Type pType, Identity::Id pOwner, size_t pRadius = 1,
+        Bomb(std::chrono::milliseconds pPlacedTime, Type pType, Identity::Id pOwner, size_t pRadius = 1,
             std::chrono::milliseconds pExplosionDelay = DEFAULT_DELAY)
-            : placedTime(std::chrono::steady_clock::now()), radius(pRadius), explosionDelay(pExplosionDelay),
-              exploded(false), owner(pOwner), type(pType){};
+            : placedTime(pPlacedTime), radius(pRadius), explosionDelay(pExplosionDelay), exploded(false), owner(pOwner),
+              type(pType){};
 
         /// Explode the bomb.
         ///

--- a/src/game/components/Player.cpp
+++ b/src/game/components/Player.cpp
@@ -50,7 +50,7 @@ namespace game::components
                 return;
             /// Item has a duration.
             if (item.duration != std::chrono::milliseconds::zero())
-                timedItems.emplace_back(itemId, std::chrono::steady_clock::now());
+                timedItems.emplace_back(itemId, data.getResource<game::resources::GameClock>().getTime());
         }
         ++count;
         Logger::logger.log(Logger::Severity::Debug, [&](auto &out) {
@@ -75,7 +75,7 @@ namespace game::components
         --count;
         /// Item has a duration.
         if (item.duration != std::chrono::milliseconds::zero())
-            timedItems.emplace_back(selected, std::chrono::steady_clock::now());
+            timedItems.emplace_back(selected, data.getResource<game::resources::GameClock>().getTime());
         Logger::logger.log(Logger::Severity::Debug, [&](auto &out) {
             out << "Player entity " << player.getId() << " activated item '" << item.name << "', " << count
                 << " left in inventory.";
@@ -150,7 +150,7 @@ namespace game::components
         GameAction bestAction = GameAction::NONE;
         float highestActionValue = 0.f;
 
-        if (std::chrono::steady_clock::now() < player.stats.stunEnd)
+        if (data.getResource<game::resources::GameClock>().getTime() < player.stats.stunEnd)
             return;
 
         for (size_t j = static_cast<size_t>(GameAction::MOVE_LEFT); j <= static_cast<size_t>(GameAction::MOVE_DOWN);
@@ -207,7 +207,7 @@ namespace game::components
 
     void Player::stun(ecs::Entity self, ecs::SystemData data, std::chrono::milliseconds duration)
     {
-        stats.stunEnd = std::chrono::steady_clock::now() + duration;
+        stats.stunEnd = data.getResource<game::resources::GameClock>().getTime() + duration;
         // Randomize the idle animation id
         auto &randDevice = data.getResource<game::resources::RandomDevice>();
         unsigned int randVal = randDevice.randInt(
@@ -250,7 +250,7 @@ namespace game::components
             auto &pair = inventory.timedItems[i];
             auto &item = Item::getItem(pair.first);
 
-            if (std::chrono::steady_clock::now() - pair.second >= item.duration) {
+            if (data.getResource<game::resources::GameClock>().getTime() - pair.second >= item.duration) {
                 item.onTimedOut(self, data);
                 inventory.timedItems.erase(inventory.timedItems.begin() + i);
             }

--- a/src/game/components/Player.cpp
+++ b/src/game/components/Player.cpp
@@ -22,6 +22,7 @@
 #include "game/components/RotationAngle.hpp"
 #include "game/components/Scale.hpp"
 #include "game/resources/AssetMap.hpp"
+#include "game/resources/GameClock.hpp"
 #include "game/resources/RandomDevice.hpp"
 #include "logger/Logger.hpp"
 #include "raylib/model/Mesh.hpp"
@@ -119,6 +120,8 @@ namespace game::components
 
     bool Player::handleActionEvent(ecs::Entity self, ecs::SystemData data, const Users::ActionEvent &event)
     {
+        if (data.getResource<game::resources::GameClock>().isPaused() && event.action != GameAction::PAUSE)
+            return false;
         if (isMoveAction(event.action))
             move(self, data, event);
         else if (event.action == GameAction::PLACE_BOMB && event.value > 0.9f)
@@ -129,6 +132,8 @@ namespace game::components
             data.getStorage<Player>()[self.getId()].inventory.selectPreviousActivable();
         else if (event.action == GameAction::NEXT_ACTIVABLE && event.value > 0.9f)
             data.getStorage<Player>()[self.getId()].inventory.selectNextActivable();
+        else if (event.action == GameAction::PAUSE && event.value > 0.9f)
+            data.getResource<game::resources::GameClock>().togglePause();
         else
             return false;
         return true;

--- a/src/game/components/Player.hpp
+++ b/src/game/components/Player.hpp
@@ -53,11 +53,11 @@ namespace game::components
             /// Player NoClip power up related states
             ClipState clipState;
             /// Time point after when the player will no longer be stunned
-            std::chrono::steady_clock::time_point stunEnd;
+            std::chrono::milliseconds stunEnd;
 
             Stats()
                 : speed(DEFAULT_SPEED), bombRange(1), bombLimit(1), inverted(false), slowness(false),
-                  clipState(ClipState::Default), stunEnd(std::chrono::steady_clock::now())
+                  clipState(ClipState::Default), stunEnd(0)
             {
             }
         };
@@ -67,7 +67,7 @@ namespace game::components
             /// Number of occurence of each item in the inventory.
             std::array<size_t, static_cast<size_t>(Item::Identifier::Count)> items;
             /// Activated items with a timer.
-            std::vector<std::pair<Item::Identifier, std::chrono::steady_clock::time_point>> timedItems;
+            std::vector<std::pair<Item::Identifier, std::chrono::milliseconds>> timedItems;
 
             /// Selected item (activable).
             Item::Identifier selected;

--- a/src/game/resources/CMakeLists.txt
+++ b/src/game/resources/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SRC
     ${SRCROOT}/Engine.hpp
     ${SRCROOT}/AssetMap.hpp
     ${SRCROOT}/Engine.hpp
+    ${SRCROOT}/GameClock.cpp
+    ${SRCROOT}/GameClock.hpp
     ${SRCROOT}/Map.hpp
     ${SRCROOT}/RandomDevice.hpp
     PARENT_SCOPE)

--- a/src/game/resources/GameClock.cpp
+++ b/src/game/resources/GameClock.cpp
@@ -1,0 +1,41 @@
+/*
+** EPITECH PROJECT, 2022
+** Bomberman
+** File description:
+** GameClock
+*/
+
+#include "GameClock.hpp"
+
+namespace game::resources
+{
+    GameClock::GameClock() : _gameTime(0), _lastReset(std::chrono::steady_clock::now()), _paused(false) {}
+
+    std::chrono::milliseconds GameClock::getTime() const { return _gameTime; }
+
+    std::chrono::milliseconds GameClock::elapsed() const
+    {
+        if (_paused)
+            return std::chrono::milliseconds::zero();
+        return std::chrono::steady_clock::now() - _lastReset;
+    }
+
+    void GameClock::update()
+    {
+        if (_paused)
+            return;
+        _gameTime += elapsed();
+        _lastReset = std::chrono::steady_clock::now();
+    }
+    void GameClock::pause(bool pause = true)
+    {
+        if (pause == _paused)
+            return;
+        if (pause)
+            update();
+        else
+            _lastReset = std::chrono::steady_clock::now();
+        _paused = pause;
+    }
+
+} // namespace game::resources

--- a/src/game/resources/GameClock.cpp
+++ b/src/game/resources/GameClock.cpp
@@ -9,7 +9,9 @@
 
 namespace game::resources
 {
-    GameClock::GameClock() : _gameTime(0), _lastReset(std::chrono::steady_clock::now()), _paused(false) {}
+    GameClock::GameClock() : _gameTime(0), _lastReset(std::chrono::steady_clock::now()), _paused(false), _lastFrame(0)
+    {
+    }
 
     std::chrono::milliseconds GameClock::getTime() const { return _gameTime; }
 
@@ -17,23 +19,32 @@ namespace game::resources
     {
         if (_paused)
             return std::chrono::milliseconds::zero();
-        return std::chrono::steady_clock::now() - _lastReset;
+        return std::chrono::duration_cast<std::chrono::milliseconds>(_lastFrame);
+    }
+
+    float GameClock::elapsedSeconds() const
+    {
+        if (_paused)
+            return 0;
+        return std::chrono::duration_cast<std::chrono::duration<float, std::ratio<1>>>(_lastFrame).count();
     }
 
     void GameClock::update()
     {
         if (_paused)
             return;
-        _gameTime += elapsed();
+        _lastFrame = std::chrono::steady_clock::now() - _lastReset;
         _lastReset = std::chrono::steady_clock::now();
+        _gameTime += elapsed();
     }
-    void GameClock::pause(bool pause = true)
+    void GameClock::pause(bool pause)
     {
         if (pause == _paused)
             return;
-        if (pause)
+        if (pause) {
             update();
-        else
+            _lastFrame = std::chrono::milliseconds(0);
+        } else
             _lastReset = std::chrono::steady_clock::now();
         _paused = pause;
     }

--- a/src/game/resources/GameClock.cpp
+++ b/src/game/resources/GameClock.cpp
@@ -49,4 +49,8 @@ namespace game::resources
         _paused = pause;
     }
 
+    void GameClock::togglePause() { pause(!_paused); }
+
+    bool GameClock::isPaused() const { return _paused; }
+
 } // namespace game::resources

--- a/src/game/resources/GameClock.hpp
+++ b/src/game/resources/GameClock.hpp
@@ -25,6 +25,9 @@ namespace game::resources
 
         void update();
         void pause(bool pause = true);
+        void togglePause();
+
+        bool isPaused() const;
 
       private:
         std::chrono::milliseconds _gameTime;

--- a/src/game/resources/GameClock.hpp
+++ b/src/game/resources/GameClock.hpp
@@ -10,6 +10,7 @@
 
 #include <chrono>
 #include "ecs/Component.hpp"
+#include "ecs/resource/Resource.hpp"
 
 namespace game::resources
 {
@@ -20,6 +21,8 @@ namespace game::resources
         std::chrono::milliseconds getTime() const;
 
         std::chrono::milliseconds elapsed() const;
+        float elapsedSeconds() const;
+
         void update();
         void pause(bool pause = true);
 
@@ -27,6 +30,7 @@ namespace game::resources
         std::chrono::milliseconds _gameTime;
         std::chrono::steady_clock::time_point _lastReset;
         bool _paused;
+        std::chrono::nanoseconds _lastFrame;
     };
 } // namespace game::resources
 

--- a/src/game/resources/GameClock.hpp
+++ b/src/game/resources/GameClock.hpp
@@ -14,19 +14,35 @@
 
 namespace game::resources
 {
+    /// Game related clock.
     class GameClock : public ecs::Resource {
       public:
+        /// Starts the clock.
         GameClock();
 
+        /// Get the effective time passed in the game.
         std::chrono::milliseconds getTime() const;
 
+        /// Get the time elapsed since the last frame.
         std::chrono::milliseconds elapsed() const;
+        /// Get the time elapsed since the last frame (in seconds).
         float elapsedSeconds() const;
 
+        /// Update the internal time. (must be call one time per frame).
         void update();
+
+        /// (Un)pause the clock. When the clock is paused, time stops: elapsed returns 0 and the internal time doesn't
+        /// change.
+        /// @param pause If the clock must be paused.
         void pause(bool pause = true);
+
+        /// Toggle the pause
         void togglePause();
 
+        /// Check if the clock is paused.
+        ///
+        /// @retval true if the clock is paused.
+        /// @retval false if the clock is running.
         bool isPaused() const;
 
       private:

--- a/src/game/resources/GameClock.hpp
+++ b/src/game/resources/GameClock.hpp
@@ -1,0 +1,33 @@
+/*
+** EPITECH PROJECT, 2022
+** Bomberman
+** File description:
+** GameClock
+*/
+
+#ifndef GAME_COMPONENTS_GAMECLOCK_HPP_
+#define GAME_COMPONENTS_GAMECLOCK_HPP_
+
+#include <chrono>
+#include "ecs/Component.hpp"
+
+namespace game::resources
+{
+    class GameClock : public ecs::Resource {
+      public:
+        GameClock();
+
+        std::chrono::milliseconds getTime() const;
+
+        std::chrono::milliseconds elapsed() const;
+        void update();
+        void pause(bool pause = true);
+
+      private:
+        std::chrono::milliseconds _gameTime;
+        std::chrono::steady_clock::time_point _lastReset;
+        bool _paused;
+    };
+} // namespace game::resources
+
+#endif /* !GAME_COMPONENTS_GAMECLOCK_HPP_ */

--- a/src/game/systems/Bomb.cpp
+++ b/src/game/systems/Bomb.cpp
@@ -11,13 +11,14 @@
 #include "game/components/Bomb.hpp"
 #include "game/components/Position.hpp"
 #include "game/components/Size.hpp"
+#include "game/resources/GameClock.hpp"
 #include "raylib/shapes/Sphere.hpp"
 
 namespace game::systems
 {
     void ExplodeBomb::run(ecs::SystemData data)
     {
-        auto now = std::chrono::steady_clock::now();
+        auto now = data.getResource<game::resources::GameClock>().getTime();
 
         for (auto [pos, bomb, id] : ecs::join(data.getStorage<game::components::Position>(),
                  data.getStorage<game::components::Bomb>(), data.getResource<ecs::Entities>())) {

--- a/src/game/systems/Movement.cpp
+++ b/src/game/systems/Movement.cpp
@@ -11,6 +11,7 @@
 #include "ecs/resource/Timer.hpp"
 #include "game/components/Position.hpp"
 #include "game/components/Velocity.hpp"
+#include "game/resources/GameClock.hpp"
 
 using namespace game::components;
 
@@ -18,7 +19,7 @@ namespace game::systems
 {
     void Movement::run(ecs::SystemData data)
     {
-        float seconds = data.getResource<ecs::Timer>().elapsed();
+        float seconds = data.getResource<game::resources::GameClock>().elapsedSeconds();
 
         for (auto [pos, vel] : ecs::join(data.getStorage<Position>(), data.getStorage<Velocity>())) {
             // no friction here, just plain old perpertual motion

--- a/src/game/systems/Movement.cpp
+++ b/src/game/systems/Movement.cpp
@@ -8,7 +8,6 @@
 #include "Movement.hpp"
 #include "ecs/Storage.hpp"
 #include "ecs/join.hpp"
-#include "ecs/resource/Timer.hpp"
 #include "game/components/Position.hpp"
 #include "game/components/Velocity.hpp"
 #include "game/resources/GameClock.hpp"
@@ -27,6 +26,5 @@ namespace game::systems
             pos.y += vel.y * seconds;
             pos.z += vel.z * seconds;
         }
-        data.getResource<ecs::Timer>().reset();
     }
 } // namespace game::systems

--- a/src/game/systems/UpdateGameClock.hpp
+++ b/src/game/systems/UpdateGameClock.hpp
@@ -1,0 +1,22 @@
+/*
+** EPITECH PROJECT, 2022
+** Bomberman
+** File description:
+** UpdateGameClock
+*/
+
+#ifndef GAME_SYSTEMS_UPDATEGAMECLOCK_HPP_
+#define GAME_SYSTEMS_UPDATEGAMECLOCK_HPP_
+
+#include "ecs/System.hpp"
+#include "game/resources/GameClock.hpp"
+
+namespace game::systems
+{
+    /// Update the game clock internal time.
+    struct UpdateGameClock : public ecs::System {
+        void run(ecs::SystemData data) override final { data.getResource<game::resources::GameClock>().update(); }
+    };
+} // namespace game::systems
+
+#endif /* !GAME_SYSTEMS_UPDATEGAMECLOCK_HPP_ */


### PR DESCRIPTION
Pause can be set using the key 'P' on keyboard (not escape because it close the window) or using the middle buttons on the gamepads.

Pause is invisible, there isn't any feedback saying that the game is paused but bomb doesn't explodes and movements doesn't applies.